### PR TITLE
Remove rcon library from package.json and redame

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,7 +29,7 @@ Download the nodejs-csgo-api-vX.X.zip and unpack.
 **OR**
 download the script files to and install the dependencies for nodejs
 ```console
-npm install --save rcon-srcds srcds-log-receiver local-ip express express-session express-rate-limit cors passport passport-steam node-pty ws winston winston-daily-rotate-file
+npm install --save srcds-log-receiver local-ip express express-session express-rate-limit cors passport passport-steam node-pty ws winston winston-daily-rotate-file
 ```
 If you want to use http authentication, add
 ```console

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "passport": ">=0.6.0",
         "passport-http": ">=0.3.0",
         "passport-steam": ">=1.0.15",
-        "rcon-srcds": "^2.0.1",
         "srcds-log-receiver": "^1.0.2",
         "winston": ">=3.3.3",
         "winston-daily-rotate-file": ">=4.5.5",


### PR DESCRIPTION
Since it is now included, no need to install it seperately